### PR TITLE
Fix a bug about `addFrame(<string>)`

### DIFF
--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -73,16 +73,18 @@ module PIXI.tilemap {
                 }
 
                 texture = layer.textures[ind];
-            } else if (typeof texture_ === "string") {
-                texture = PIXI.Texture.fromImage(texture_);
             } else {
-                texture = texture_ as PIXI.Texture;
+                if (typeof texture_ === "string") {
+                    texture = PIXI.Texture.fromImage(texture_);
+                } else {
+                    texture = texture_ as PIXI.Texture;
+                }
 
                 for (var i = 0; i < children.length; i++) {
                     var child = children[i] as RectTileLayer;
                     var tex = child.textures;
                     for (var j = 0; j < tex.length; j++) {
-                        if (tex[j].baseTexture == texture.baseTexture) {
+                        if (tex[j].baseTexture === texture.baseTexture) {
                             layer = child;
                             ind = j;
                             break;


### PR DESCRIPTION
In current version , when use  addFrame('textureName') ,
the `layer` will always be null.

This PR could fix this bug.