### PR TITLE
Just post glTextures-used to shader

### DIFF
--- a/src/TileRenderer.ts
+++ b/src/TileRenderer.ts
@@ -106,8 +106,10 @@ module PIXI.tilemap {
                     }
                 }
             }
+
+            var gltsUsed = i >> 2;
             this.texLoc.length = 0;
-            for (i = 0; i < maxTextures; i++) {
+            for (i = 0; i <= gltsUsed; i++) {
                 //remove "i, true" after resolving a bug
                 this.texLoc.push(renderer.bindTexture(glts[i], i, true))
             }

--- a/src/TileRenderer.ts
+++ b/src/TileRenderer.ts
@@ -107,12 +107,13 @@ module PIXI.tilemap {
                 }
             }
 
-            var gltsUsed = i >> 2;
             this.texLoc.length = 0;
-            for (i = 0; i <= gltsUsed; i++) {
+            var gltsUsed = (i + 3) >> 2;
+            for (i = 0; i < gltsUsed; i++) {
                 //remove "i, true" after resolving a bug
                 this.texLoc.push(renderer.bindTexture(glts[i], i, true))
             }
+            
             shader.uniforms.uSamplers = this.texLoc;
         }
 

--- a/src/TileRenderer.ts
+++ b/src/TileRenderer.ts
@@ -113,7 +113,7 @@ module PIXI.tilemap {
                 //remove "i, true" after resolving a bug
                 this.texLoc.push(renderer.bindTexture(glts[i], i, true))
             }
-            
+
             shader.uniforms.uSamplers = this.texLoc;
         }
 


### PR DESCRIPTION
In current pixi-tilemap , it always posts all `glTextures` (PIXI.RenderTexture * 4) to shader.
But sometimes , we don't use all glTextures.   e.g. :  the  demo-basic just uses 1 , the demo-rpgmaker just uses 2.