### PR TITLE
tilemap ignores visible property

### DIFF
--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -131,7 +131,9 @@ namespace pixi_tilemap {
         }
 
         renderCanvas(renderer: PIXI.CanvasRenderer) {
-            if(!this.visible) return;
+            if (!this.visible || this.worldAlpha <= 0 || !this.renderable) {
+                return;
+            }
             var plugin = renderer.plugins.tilemap;
             if (!plugin.dontUseTransform) {
                 var wt = this.worldTransform;
@@ -151,7 +153,9 @@ namespace pixi_tilemap {
         }
 
         renderWebGL(renderer: PIXI.WebGLRenderer) {
-            if(!this.visible) return;
+            if (!this.visible || this.worldAlpha <= 0 || !this.renderable) {
+                return;
+            }
             var gl = renderer.gl;
             var plugin = renderer.plugins.tilemap;
             var shader = plugin.getShader();

--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -131,6 +131,7 @@ namespace pixi_tilemap {
         }
 
         renderCanvas(renderer: PIXI.CanvasRenderer) {
+            if(!this.visible) return;
             var plugin = renderer.plugins.tilemap;
             if (!plugin.dontUseTransform) {
                 var wt = this.worldTransform;
@@ -150,6 +151,7 @@ namespace pixi_tilemap {
         }
 
         renderWebGL(renderer: PIXI.WebGLRenderer) {
+            if(!this.visible) return;
             var gl = renderer.gl;
             var plugin = renderer.plugins.tilemap;
             var shader = plugin.getShader();


### PR DESCRIPTION
I split world on few tilemaps and hide some of them if they not in screen area. But when i set tilemap.visible = false, tilemap freezes at one place and stays visible.
This fix selves problem.