### PR TITLE
Tile flipping

### DIFF
--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -66,7 +66,7 @@ namespace pixi_tilemap {
             }
         }
 
-        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, flags: number, animX?: number, animY?: number) {
+        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, flags: number = 0, animX?: number, animY?: number) {
             let texture: PIXI.Texture;
             let layer: RectTileLayer = null;
             let ind: number = 0;

--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -57,16 +57,16 @@ namespace pixi_tilemap {
             this.modificationMarker = 0;
         }
 
-        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number) {
+        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number, flags: number) {
             const childIndex: number = textureIndex / this.texPerChild >> 0;
             const textureId: number = textureIndex % this.texPerChild;
 
             if (this.children[childIndex] && (this.children[childIndex] as RectTileLayer).textures) {
-                (this.children[childIndex] as RectTileLayer).addRect(textureId, u, v, x, y, tileWidth, tileHeight);
+                (this.children[childIndex] as RectTileLayer).addRect(textureId, u, v, x, y, tileWidth, tileHeight, flags);
             }
         }
 
-        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, animX?: number, animY?: number) {
+        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, flags: number, animX?: number, animY?: number) {
             let texture: PIXI.Texture;
             let layer: RectTileLayer = null;
             let ind: number = 0;
@@ -130,7 +130,7 @@ namespace pixi_tilemap {
                 }
             }
 
-            layer.addRect(ind, texture.frame.x, texture.frame.y, x, y, texture.frame.width, texture.frame.height, animX, animY);
+            layer.addRect(ind, texture.frame.x, texture.frame.y, x, y, texture.frame.width, texture.frame.height, flags, animX, animY);
             return true;
         }
 


### PR DESCRIPTION
Implemented horizontal, vertical and diagonal [flipping](http://doc.mapeditor.org/en/stable/reference/tmx-map-format/?highlight=diagonal#tile-flipping)  of tiles, which is necessary when importing tilemaps from the popular [TILED editor](https://www.mapeditor.org/).
Works only with rectangular tiles.