### PR TITLE
add animWidth and animHeight to limit frame cycles of individual anim…

### DIFF
--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -57,16 +57,16 @@ namespace pixi_tilemap {
             this.modificationMarker = 0;
         }
 
-        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number, animX?: number, animY?: number, rotate?: number) {
+        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number, animX?: number, animY?: number, rotate?: number, animWidth?: number, animHeight?: number) {
             const childIndex: number = textureIndex / this.texPerChild >> 0;
             const textureId: number = textureIndex % this.texPerChild;
 
             if (this.children[childIndex] && (this.children[childIndex] as RectTileLayer).textures) {
-                (this.children[childIndex] as RectTileLayer).addRect(textureId, u, v, x, y, tileWidth, tileHeight, animX, animY, rotate);
+                (this.children[childIndex] as RectTileLayer).addRect(textureId, u, v, x, y, tileWidth, tileHeight, animX, animY, rotate, animWidth, animHeight);
             }
         }
 
-        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, animX?: number, animY?: number) {
+        addFrame(texture_: PIXI.Texture | String | number, x: number, y: number, animX?: number, animY?: number, animWidth?: number, animHeight?: number) {
             var texture: PIXI.Texture;
             var layer: RectTileLayer = null;
             var ind: number = 0;
@@ -130,7 +130,7 @@ namespace pixi_tilemap {
                 }
             }
 
-            layer.addRect(ind, texture.frame.x, texture.frame.y, x, y, texture.orig.width, texture.orig.height, animX, animY, texture.rotate);
+            layer.addRect(ind, texture.frame.x, texture.frame.y, x, y, texture.orig.width, texture.orig.height, animX, animY, texture.rotate, animWidth, animHeight);
             return true;
         }
 

--- a/src/RectTileLayer.ts
+++ b/src/RectTileLayer.ts
@@ -3,7 +3,7 @@ namespace pixi_tilemap {
     import glCore = PIXI.glCore;
     import GroupD8 = PIXI.GroupD8;
 
-    export const POINT_STRUCT_SIZE = 10;
+    export const POINT_STRUCT_SIZE = 12;
 
     export class RectTileLayer extends PIXI.Container {
 
@@ -82,7 +82,7 @@ namespace pixi_tilemap {
             return true;
         }
 
-        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number, animX: number = 0, animY: number = 0, rotate: number = 0) {
+        addRect(textureIndex: number, u: number, v: number, x: number, y: number, tileWidth: number, tileHeight: number, animX: number = 0, animY: number = 0, rotate: number = 0, animWidth: number = 1, animHeight: number = 1) {
             const pb = this.pointsBuf;
             this.hasAnim = this.hasAnim || animX > 0 || animY > 0;
 
@@ -96,6 +96,8 @@ namespace pixi_tilemap {
             pb.push(animX);
             pb.push(animY);
             pb.push(textureIndex);
+            pb.push(animWidth);
+            pb.push(animHeight);
         }
 
         renderCanvas(renderer: PIXI.CanvasRenderer) {
@@ -262,6 +264,7 @@ namespace pixi_tilemap {
                     let rotate = points[i + 6];
                     let u = points[i] + shiftU, v = points[i + 1] + shiftV;
                     let animX = points[i + 7], animY = points[i + 8];
+                    var animWidth = points[i + 10], animHeight = points[i + 11];
 
                     let u0: number, v0: number, u1: number, v1: number, u2: number, v2: number, u3: number, v3: number;
                     if (rotate === 0) {
@@ -311,6 +314,8 @@ namespace pixi_tilemap {
                     arr[sz++] = animX;
                     arr[sz++] = animY;
                     arr[sz++] = textureId;
+                    arr[sz++] = animWidth;
+                    arr[sz++] = animHeight;
                     arr[sz++] = x + w;
                     arr[sz++] = y;
                     arr[sz++] = u1;
@@ -322,6 +327,8 @@ namespace pixi_tilemap {
                     arr[sz++] = animX;
                     arr[sz++] = animY;
                     arr[sz++] = textureId;
+                    arr[sz++] = animWidth;
+                    arr[sz++] = animHeight;
                     arr[sz++] = x + w;
                     arr[sz++] = y + h;
                     arr[sz++] = u2;
@@ -333,6 +340,8 @@ namespace pixi_tilemap {
                     arr[sz++] = animX;
                     arr[sz++] = animY;
                     arr[sz++] = textureId;
+                    arr[sz++] = animWidth;
+                    arr[sz++] = animHeight;
                     arr[sz++] = x;
                     arr[sz++] = y + h;
                     arr[sz++] = u3;
@@ -344,6 +353,8 @@ namespace pixi_tilemap {
                     arr[sz++] = animX;
                     arr[sz++] = animY;
                     arr[sz++] = textureId;
+                    arr[sz++] = animWidth;
+                    arr[sz++] = animHeight;
                 }
 
                 // if (vs > this.vbArray.length/2 ) {

--- a/src/RectTileShader.ts
+++ b/src/RectTileShader.ts
@@ -39,7 +39,7 @@ varying vec4 vFrame;
 
 void main(void){
    gl_Position = vec4((projectionMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
-   vec2 anim = aAnim * mod(animationFrame, vec2(aAnimWidth, aAnimHeight));
+   vec2 anim = aAnim * mod(animationFrame + 1.0, vec2(aAnimWidth, aAnimHeight));
    vTextureCoord = aTextureCoord + anim;
    vFrame = aFrame + vec4(anim, anim);
    vTextureId = aTextureId;

--- a/src/RectTileShader.ts
+++ b/src/RectTileShader.ts
@@ -39,7 +39,7 @@ varying vec4 vFrame;
 
 void main(void){
    gl_Position = vec4((projectionMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
-   vec2 anim = aAnim * vec2(mod(animationFrame.x, aAnimWidth), mod(animationFrame.y, aAnimHeight));
+   vec2 anim = aAnim * mod(animationFrame, vec2(aAnimWidth, aAnimHeight));
    vTextureCoord = aTextureCoord + anim;
    vFrame = aFrame + vec4(anim, anim);
    vTextureId = aTextureId;

--- a/src/RectTileShader.ts
+++ b/src/RectTileShader.ts
@@ -27,6 +27,8 @@ attribute vec2 aTextureCoord;
 attribute vec4 aFrame;
 attribute vec2 aAnim;
 attribute float aTextureId;
+attribute float aAnimWidth;
+attribute float aAnimHeight;
 
 uniform mat3 projectionMatrix;
 uniform vec2 animationFrame;
@@ -37,7 +39,7 @@ varying vec4 vFrame;
 
 void main(void){
    gl_Position = vec4((projectionMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
-   vec2 anim = aAnim * animationFrame;
+   vec2 anim = aAnim * vec2(mod(animationFrame.x, aAnimWidth), mod(animationFrame.y, aAnimHeight));
    vTextureCoord = aTextureCoord + anim;
    vFrame = aFrame + vec4(anim, anim);
    vTextureId = aTextureId;
@@ -62,7 +64,7 @@ void main(void){
     }
 
     export class RectTileShader extends TilemapShader {
-        vertSize = 11;
+        vertSize = pixi_tilemap.POINT_STRUCT_SIZE + 1;
         vertPerQuad = 4;
         stride = this.vertSize * 4;
 
@@ -83,7 +85,9 @@ void main(void){
                 .addAttribute(vb, this.attributes.aTextureCoord, gl.FLOAT, false, this.stride, 2 * 4)
                 .addAttribute(vb, this.attributes.aFrame, gl.FLOAT, false, this.stride, 4 * 4)
                 .addAttribute(vb, this.attributes.aAnim, gl.FLOAT, false, this.stride, 8 * 4)
-                .addAttribute(vb, this.attributes.aTextureId, gl.FLOAT, false, this.stride, 10 * 4);
+                .addAttribute(vb, this.attributes.aTextureId, gl.FLOAT, false, this.stride, 10 * 4)
+                .addAttribute(vb, this.attributes.aAnimWidth, gl.FLOAT, false, this.stride, 11 * 4)
+                .addAttribute(vb, this.attributes.aAnimHeight, gl.FLOAT, false, this.stride, 12 * 4);
         }
     }
 


### PR DESCRIPTION
This adds the ability to (cheaply) limit individual animated frame cycles to their respective animated frame strips width and height.
![frameCycle](https://user-images.githubusercontent.com/6495061/75292670-8ca25980-581c-11ea-945e-2ef73855f313.gif)
The coin has 9 consecutive frames, the viking on the right has 5, the grass has three.
The viking in the middle is the edge case that I plan to fix with a different workaround - he is the one that has frames scattered at  different locations on my tileset


It is a part of an effort to get #3 and #76 sorted to a pleasing level as well as bundle pixi-tilemap with gdevelop game engine
https://github.com/4ian/GDevelop/issues/503

I explain why this is required here
https://github.com/pixijs/pixi-tilemap/issues/76#issuecomment-590252796

Here is an entire tmx file data parsed scene (from a json file actually, exported by tiled),  rendered entirely via pixi-tilemap
![pixi-tilemap-parsing-tmx-data](https://user-images.githubusercontent.com/6495061/75293150-81036280-581d-11ea-8bdc-aa35967e9a34.png)

with several layers of animated and non animated tiles + objects and object groups

